### PR TITLE
Add share-between-container class to ShareLink widget

### DIFF
--- a/widgets/ShareLink.php
+++ b/widgets/ShareLink.php
@@ -24,7 +24,7 @@ class ShareLink extends Widget
             return '';
         }
 
-        if ((int) $this->record->content->visibility !== Content::VISIBILITY_PUBLIC) {
+        if ((int)$this->record->content->visibility !== Content::VISIBILITY_PUBLIC) {
             return '';
         }
 
@@ -41,7 +41,8 @@ class ShareLink extends Widget
                 Yii::t('SharebetweenModule.base', 'Share') . $this->getCounter(),
                 ['/sharebetween/share', 'id' => $this->record->content->id],
                 ['data-target' => '#globalModal']
-            )
+            ),
+            ['class' => 'share-between-container']
         );
     }
 


### PR DESCRIPTION
@luke- This would allow targeting the "Share" link with CSS.
I will use it with the Clean Theme to change it to an icon:

![image](https://github.com/humhub/sharebetween/assets/23310825/65ebe0e2-6520-4506-8564-a6103abc4388)

![image](https://github.com/humhub/sharebetween/assets/23310825/649bef42-d0bd-40e3-8474-2667840ac570)

Thanks!